### PR TITLE
Alternative implementation using existing `bits` and `bytes` attributes

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -122,7 +122,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let id = input.id.as_ref();
     let id_type = input.id_type.as_ref();
 
-    let id_args = gen_id_args(input.endian.as_ref(), input.bits)?;
+    let id_args = gen_id_args(input.endian.as_ref(), input.bits.as_ref())?;
 
     let magic_read = emit_magic_read(input)?;
 
@@ -346,7 +346,7 @@ fn emit_field_read(
     let field_read_func = if field_reader.is_some() {
         quote! { #field_reader }
     } else {
-        let read_args = gen_field_args(field_endian, f.bits, f.ctx.as_ref())?;
+        let read_args = gen_field_args(field_endian, f.bits.as_ref(), f.ctx.as_ref())?;
 
         // The container limiting options are special, we need to generate `(limit, (other, ..))` for them.
         // These have a problem where when it isn't a copy type, the field will be moved.
@@ -360,13 +360,6 @@ fn emit_field_read(
                 {
                     use core::borrow::Borrow;
                     DekuRead::read(rest, (usize::try_from(*((#field_count).borrow()))?.into(), (#read_args)))
-                }
-            }
-        } else if let Some(field_bits) = &f.bits_read {
-            quote! {
-                {
-                    use core::borrow::Borrow;
-                    DekuRead::read(rest, (deku::ctx::BitSize(usize::try_from(*((#field_bits).borrow()))?).into(), (#read_args)))
                 }
             }
         } else if let Some(field_until) = &f.until {

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -156,7 +156,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let id = input.id.as_ref();
     let id_type = input.id_type.as_ref();
 
-    let id_args = gen_id_args(input.endian.as_ref(), input.bits)?;
+    let id_args = gen_id_args(input.endian.as_ref(), input.bits.as_ref())?;
 
     let mut variant_writes = vec![];
     let mut variant_updates = vec![];
@@ -417,7 +417,7 @@ fn emit_field_write(
     let field_write_func = if field_writer.is_some() {
         quote! { #field_writer }
     } else {
-        let write_args = gen_field_args(field_endian, f.bits, f.ctx.as_ref())?;
+        let write_args = gen_field_args(field_endian, f.bits.as_ref(), f.ctx.as_ref())?;
 
         quote! { #object_prefix #field_ident.write(output, (#write_args)) }
     };

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -161,7 +161,10 @@ fn gen_ctx_types_and_arg(
 
 /// Generate argument for `id`:
 /// `#deku(endian = "big", bits = "1")` -> `Endian::Big, BitSize(1)`
-fn gen_id_args(endian: Option<&syn::LitStr>, bits: Option<usize>) -> syn::Result<TokenStream> {
+fn gen_id_args(
+    endian: Option<&syn::LitStr>,
+    bits: Option<&TokenStream>,
+) -> syn::Result<TokenStream> {
     let endian = endian.map(gen_endian_from_str).transpose()?;
     let bits = bits.map(|n| quote! {deku::ctx::BitSize(#n)});
 
@@ -182,7 +185,7 @@ fn gen_id_args(endian: Option<&syn::LitStr>, bits: Option<usize>) -> syn::Result
 /// `#deku(endian = "big", bits = "1", ctx = "a")` -> `Endian::Big, BitSize(1), a`
 fn gen_field_args(
     endian: Option<&syn::LitStr>,
-    bits: Option<usize>,
+    bits: Option<&TokenStream>,
     ctx: Option<&Punctuated<syn::Expr, syn::token::Comma>>,
 ) -> syn::Result<TokenStream> {
     let endian = endian.map(gen_endian_from_str).transpose()?;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -10,8 +10,6 @@ A documentation-only module for #\[deku\] attributes
 | [bits](#bits) | field | Set the bit-size of the field
 | [bytes](#bytes) | field | Set the byte-size of the field
 | [count](#count) | field | Set the field representing the element count of a container
-| [bits_read](#bits_read) | field | Set the field representing the number of bits to read into a container
-| [bytes_read](#bytes_read) | field | Set the field representing the number of bytes to read into a container
 | [until](#until) | field | Set a predicate returning when to stop reading elements into a container
 | [update](#update) | field | Apply code over the field when `.update()` is called
 | [skip](#skip) | field | Skip the reading/writing of a field
@@ -146,9 +144,9 @@ Example:
 # use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
-    #[deku(bits = 2)]
+    #[deku(bits = "2")]
     field_a: u8,
-    #[deku(bits = 6)]
+    #[deku(bits = "6")]
     field_b: u8,
     field_c: u8, // defaults to size_of<u8>*8
 }
@@ -182,7 +180,7 @@ Example:
 # use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
-    #[deku(bytes = 2)]
+    #[deku(bytes = "2")]
     field_a: u32,
     field_b: u8, // defaults to size_of<u8>
 }
@@ -236,58 +234,6 @@ assert_eq!(data, value);
 ```
 
 **Note**: See [update](#update) for more information on the attribute!
-
-
-# bytes_read
-
-Specify the field representing the total number of bytes to read into a container
-
-See the following example, where `InnerDekuTest` is 2 bytes, so setting `bytes_read` to
-4 will read 2 items into the container:
-```rust
-# use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
-# #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-struct InnerDekuTest {
-    field_a: u8,
-    field_b: u8
-}
-
-# #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-struct DekuTest {
-    #[deku(update = "(self.items.len() / 2)")]
-    bytes: u8,
-
-    #[deku(bytes_read = "bytes")]
-    items: Vec<InnerDekuTest>,
-}
-
-let data: Vec<u8> = vec![0x04, 0xAB, 0xBC, 0xDE, 0xEF];
-
-let value = DekuTest::try_from(data.as_ref()).unwrap();
-
-assert_eq!(
-    DekuTest {
-       bytes: 0x04,
-       items: vec![
-           InnerDekuTest{field_a: 0xAB, field_b: 0xBC},
-           InnerDekuTest{field_a: 0xDE, field_b: 0xEF}],
-    },
-    value
-);
-
-let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
-```
-
-**Note**: See [update](#update) for more information on the attribute!
-
-
-# bits_read
-
-This is equivalent to [bytes_read](#bytes_read), however specifies the bit limit instead
-of a byte limit
-
 
 # until
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,6 +534,34 @@ fn read_vec_with_predicate<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(usize, 
     Ok((rest, res))
 }
 
+impl<T: DekuRead> DekuRead<BitSize> for Vec<T> {
+    fn read(
+        input: &BitSlice<Msb0, u8>,
+        bit_size: BitSize,
+    ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError>
+    where
+        Self: Sized,
+    {
+        read_vec_with_predicate(input, None, (), move |read_bits, _| {
+            read_bits == bit_size.into()
+        })
+    }
+}
+
+impl<T: DekuRead<Endian>> DekuRead<(Endian, BitSize)> for Vec<T> {
+    fn read(
+        input: &BitSlice<Msb0, u8>,
+        (endian, bit_size): (Endian, BitSize),
+    ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError>
+    where
+        Self: Sized,
+    {
+        read_vec_with_predicate(input, None, endian, move |read_bits, _| {
+            read_bits == bit_size.into()
+        })
+    }
+}
+
 impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<T, Predicate>, Ctx)>
     for Vec<T>
 {

--- a/tests/test_attributes/test_vec_limits/test_bits_read.rs
+++ b/tests/test_attributes/test_vec_limits/test_bits_read.rs
@@ -2,10 +2,10 @@ use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
 
 #[test]
-fn test_bits_read_static() {
+fn test_bits_static() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
-        #[deku(endian = "little", bits_read = "16")]
+        #[deku(endian = "little", bits = "16")]
         data: Vec<u16>,
     }
 
@@ -29,12 +29,12 @@ fn test_bits_read_static() {
 }
 
 #[test]
-fn test_bits_read_from_field() {
+fn test_bits_from_field() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
         bits: u8,
 
-        #[deku(endian = "little", bits_read = "bits")]
+        #[deku(endian = "little", bits = "*bits")]
         data: Vec<u16>,
     }
 
@@ -63,12 +63,12 @@ fn test_bits_read_from_field() {
 
 #[test]
 #[should_panic(expected = "Parse(\"not enough data: expected 16 bits got 0 bits\")")]
-fn test_bits_read_error() {
+fn test_bits_error() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
         bits: u8,
 
-        #[deku(endian = "little", bits_read = "bits")]
+        #[deku(endian = "little", bits = "*bits")]
         data: Vec<u16>,
     }
 

--- a/tests/test_attributes/test_vec_limits/test_bytes_read.rs
+++ b/tests/test_attributes/test_vec_limits/test_bytes_read.rs
@@ -2,10 +2,10 @@ use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
 
 #[test]
-fn test_bytes_read_static() {
+fn test_bytes_static() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
-        #[deku(endian = "little", bytes_read = "2")]
+        #[deku(endian = "little", bytes = "2")]
         data: Vec<u16>,
     }
 
@@ -29,12 +29,12 @@ fn test_bytes_read_static() {
 }
 
 #[test]
-fn test_bytes_read_from_field() {
+fn test_bytes_from_field() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
         bytes: u8,
 
-        #[deku(endian = "little", bytes_read = "bytes")]
+        #[deku(endian = "little", bytes = "*bytes")]
         data: Vec<u16>,
     }
 
@@ -63,12 +63,12 @@ fn test_bytes_read_from_field() {
 
 #[test]
 #[should_panic(expected = "Parse(\"not enough data: expected 16 bits got 0 bits\")")]
-fn test_bytes_read_error() {
+fn test_bytes_error() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {
         bytes: u8,
 
-        #[deku(endian = "little", bytes_read = "bytes")]
+        #[deku(endian = "little", bytes = "*bytes")]
         data: Vec<u16>,
     }
 

--- a/tests/test_compile/cases/bits_bytes_conflict.stderr
+++ b/tests/test_compile/cases/bits_bytes_conflict.stderr
@@ -1,31 +1,23 @@
 error: conflicting: both `bits` and `bytes` specified on enum
- --> $DIR/bits_bytes_conflict.rs:3:10
+ --> $DIR/bits_bytes_conflict.rs:4:28
   |
-3 | #[derive(DekuRead)]
-  |          ^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+4 | #[deku(type = "u8", bits = "1", bytes = "2")]
+  |                            ^^^
 
 error: conflicting: both `bits` and `bytes` specified on field
- --> $DIR/bits_bytes_conflict.rs:7:10
-  |
-7 | #[derive(DekuRead)]
-  |          ^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $DIR/bits_bytes_conflict.rs:10:21
+   |
+10 |     A(#[deku(bits = "1", bytes = "2")] u8),
+   |                     ^^^
 
 error: conflicting: both `bits` and `bytes` specified on field
-  --> $DIR/bits_bytes_conflict.rs:17:10
+  --> $DIR/bits_bytes_conflict.rs:19:19
    |
-17 | #[derive(DekuRead)]
-   |          ^^^^^^^^
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+19 |     #[deku(bits = "5", bytes = "6")]
+   |                   ^^^
 
 error: conflicting: both `bits` and `bytes` specified on field
-  --> $DIR/bits_bytes_conflict.rs:23:10
+  --> $DIR/bits_bytes_conflict.rs:24:28
    |
-23 | #[derive(DekuRead)]
-   |          ^^^^^^^^
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+24 | struct Test4(#[deku(bits = "7", bytes = "8")] u8);
+   |                            ^^^

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -23,20 +23,16 @@ error: `type` only supported on enum
    |               ^^^^
 
 error: `bits` only supported on enum
-  --> $DIR/enum_validation.rs:27:10
+  --> $DIR/enum_validation.rs:28:15
    |
-27 | #[derive(DekuRead)]
-   |          ^^^^^^^^
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+28 | #[deku(bits = "1")]
+   |               ^^^
 
 error: `bits` only supported on enum
-  --> $DIR/enum_validation.rs:34:10
+  --> $DIR/enum_validation.rs:35:15
    |
-34 | #[derive(DekuRead)]
-   |          ^^^^^^^^
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+35 | #[deku(bits = "1")]
+   |               ^^^
 
 error: `id` only supported on enum
   --> $DIR/enum_validation.rs:42:13

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -12,7 +12,7 @@ pub enum TestEnum {
     #[deku(id = "1")]
     VarA(u8),
     #[deku(id = "2")]
-    VarB(#[deku(bits = 4)] u8, #[deku(bits = 4)] u8),
+    VarB(#[deku(bits = "4")] u8, #[deku(bits = "4")] u8),
     #[deku(id = "3")]
     VarC {
         #[deku(update = "field_b.len()")]

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -3,7 +3,7 @@ use deku::prelude::*;
 #[test]
 fn test_from_bytes_struct() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    struct TestDeku(#[deku(bits = 4)] u8);
+    struct TestDeku(#[deku(bits = "4")] u8);
 
     let test_data: Vec<u8> = [0b0110_0110u8, 0b0101_1010u8].to_vec();
 


### PR DESCRIPTION
Hey @samuelsleight I thought I'd propose some changes to your PR based on my comment in https://github.com/sharksforarms/deku/issues/76 :) ( :+1:  collaboration :100: )

TODO:
- attributes.rs docs update for bits/bytes
- possibly optimize the receiver, `bits = 4` or `bits = "4"` should both be ok (literal vs tokens)